### PR TITLE
linted ruby code using rubocop standard

### DIFF
--- a/templates/ruby/create_gemfile.rb
+++ b/templates/ruby/create_gemfile.rb
@@ -1,12 +1,30 @@
 require 'json'
-version=JSON.parse(`gauge -v --machine-readable`)['plugins'].find {|x| x['name'] == 'ruby'}['version'] rescue nil
-if (!version.nil? && version.include?("nightly")) || ENV["GAUGE_SOURCE_BUILD"] =='true'
-    v=version.split('.nightly').first
-    File.open("Gemfile", 'w') { |file| file.write("gem 'test-unit', :group => [:development, :test]\ngem 'gauge-ruby', '~>#{v}', :github => 'getgauge/gauge-ruby', :ref => 'HEAD', :group => [:development, :test]\n") }
+plugins = JSON.parse(`gauge -v --machine-readable`)['plugins']
+unless plugins.nil?
+  ruby_plugin = plugins.find do |x|
+    x['name'] == 'ruby'
+  end || {}
+  version = ruby_plugin['version']
+end
+if version.to_s.include?('nightly') || ENV['GAUGE_SOURCE_BUILD'] == 'true'
+  v = version.split('.nightly').first
+  File.open('Gemfile', 'w') do |file|
+    file.write(
+      "gem 'test-unit', group: [:development, :test]\n"\
+      "gem 'gauge-ruby', '~>#{v}', github: 'getgauge/gauge-ruby',"\
+      " ref: 'HEAD', group: [:development, :test]\n"
+    )
+  end
 else
-	File.open("Gemfile", 'w') { |file| file.write("source \"https://rubygems.org\"\n\ngem 'test-unit', :group => [:development, :test]\ngem 'gauge-ruby', '~>#{version}', :group => [:development, :test]\n") }
+  File.open('Gemfile', 'w') do |file|
+    file.write(
+      "source 'https://rubygems.org'\n\n"\
+      "gem 'test-unit', group: [:development, :test]\n"\
+      "gem 'gauge-ruby', '~>#{version}', group: [:development, :test]\n"
+    )
+  end
 end
 
-system %w[bundle install]
+system %w(bundle install)
 
 File.delete __FILE__

--- a/templates/ruby/step_implementations/step_implementation.rb
+++ b/templates/ruby/step_implementations/step_implementation.rb
@@ -1,23 +1,23 @@
 require 'test/unit'
 include Test::Unit::Assertions
 
-@vowels = nil;
+@vowels = nil
 
 step 'Vowels in English language are <vowels>.' do |vowels|
-   @vowels = vowels.scan(/./);
+  @vowels = vowels.scan(/./)
 end
 
-step 'The word <word> has <count> vowels.' do |word, expectedCount|
-  assert_equal(expectedCount.to_i, count_vowels(word))
+step 'The word <word> has <count> vowels.' do |word, expected_count|
+  assert_equal(expected_count.to_i, count_vowels(word))
 end
 
-step 'Almost all words have vowels <table>' do |wordsTable|
-  wordsTable.rows().each do |row|
-   word = row['Word'];
-   expectedCount = row['Vowel Count'].to_i
-   actualCount = count_vowels(word)
-   assert_equal(expectedCount, actualCount)
- end
+step 'Almost all words have vowels <table>' do |words_table|
+  words_table.rows.each do |row|
+    word = row['Word']
+    expected_count = row['Vowel Count'].to_i
+    actual_count = count_vowels(word)
+    assert_equal(expected_count, actual_count)
+  end
 end
 
 def count_vowels(string)

--- a/templates/ruby_selenium/Gemfile
+++ b/templates/ruby_selenium/Gemfile
@@ -1,7 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 group :test do
-	gem 'gauge-ruby', '~>0.4.0'
-	gem 'test-unit', '~> 3.2.3'
-	gem 'selenium-webdriver', '~> 3.1.0'
+  gem 'gauge-ruby', '~>0.4.0'
+  gem 'selenium-webdriver', '~> 3.1.0'
+  gem 'test-unit', '~> 3.2.3'
 end

--- a/templates/ruby_selenium/step_implementations/driver.rb
+++ b/templates/ruby_selenium/step_implementations/driver.rb
@@ -1,18 +1,20 @@
 require 'selenium-webdriver'
 
+# Driver module for selenium web driver
 module Driver
-    def driver
-        @@driver
-    end
-    
-    before_suite do
-        # init driver from DriverFactory
-        # set the "browser" env variable in one of the properties files. check env/default/default.properties
-        @@driver = Selenium::WebDriver.for ENV["browser"].to_sym
-    end
+  def driver
+    @@driver
+  end
 
-    after_suite do
-        # quit driver
-        @@driver.quit
-    end
+  before_suite do
+    # init driver from DriverFactory
+    # set the "browser" env variable in one of the properties files.
+    # check env/default/default.properties
+    @@driver = Selenium::WebDriver.for ENV['browser'].to_sym
+  end
+
+  after_suite do
+    # quit driver
+    @@driver.quit
+  end
 end

--- a/templates/ruby_selenium/step_implementations/step_implementation.rb
+++ b/templates/ruby_selenium/step_implementations/step_implementation.rb
@@ -5,11 +5,11 @@ include Test::Unit::Assertions
 include ::Driver
 
 step 'Navigate to Gauge homepage <url>' do |url|
-    driver.navigate.to url
-    assert_equal driver.title(), 'Gauge | ThoughtWorks'
+  driver.navigate.to url
+  assert_equal driver.title, 'Gauge | ThoughtWorks'
 end
 
 step 'Go to Gauge Get Started Page' do
-    get_started_btn = driver.find_element(:link_text, "Get Started")
-    get_started_btn.click()
+  get_started_btn = driver.find_element(:link_text, 'Get Started')
+  get_started_btn.click
 end


### PR DESCRIPTION
I have fork your ruby template and linted it using Rubocop.
This can help when people initial a new project, they would get **100% linter pass**, and more friendly code.

What I have changed are
1. Fix some **indent**
2. Remove **semicolon** ( ruby doesn't need it )
3. Change the **variable's name** from **CamelCase** to **snake_case** ( ruby comunity standard )
4. Some **too long** code
