### PR TITLE
Make the maven installs silent and non interactive

### DIFF
--- a/templates/java_maven/metadata.json
+++ b/templates/java_maven/metadata.json
@@ -3,6 +3,6 @@
   "description": "Gauge template for Java plugin with Maven as Build tool",
   "version": "0.0.1",
 
-  "postInstallCmd" : "mvn archetype:generate -DarchetypeArtifactId=gauge-archetype-java -DarchetypeGroupId=com.thoughtworks.gauge.maven -DinteractiveMode=true",
-  "postInstallMsg" : "Run specifications with \"mvn clean test\" in project root."
+  "postInstallCmd" : "mvn -q -B archetype:generate -DarchetypeArtifactId=gauge-archetype-java -DarchetypeGroupId=com.thoughtworks.gauge.maven -DinteractiveMode=false -DinteractiveMode=false -DgroupId=com.sample -DartifactId=sample -Dversion=1.0-SNAPSHOT -Dpackage=com.sample.project",
+  "postInstallMsg" : "Run specifications with \"mvn clean test\" inside the \"sample\" directory."
 }

--- a/templates/java_maven_selenium/metadata.json
+++ b/templates/java_maven_selenium/metadata.json
@@ -3,6 +3,6 @@
   "description": "Gauge template for Java plugin with Maven as Build tool and Selenium as driver to interact with a web browser",
   "version": "0.0.1",
 
-  "postInstallCmd" : "mvn archetype:generate -DarchetypeArtifactId=gauge-archetype-selenium -DarchetypeGroupId=com.thoughtworks.gauge.maven -DinteractiveMode=true",
-  "postInstallMsg" : "Run specifications with \"mvn clean test\" in project root."
+  "postInstallCmd" : "mvn -q -B archetype:generate -DarchetypeArtifactId=gauge-archetype-selenium -DarchetypeGroupId=com.thoughtworks.gauge.maven -DinteractiveMode=false -DgroupId=com.sample -DartifactId=sample -Dversion=1.0-SNAPSHOT -Dpackage=com.sample.project",
+  "postInstallMsg" : "Run specifications with \"mvn clean test\" inside the \"sample\" directory."
 }


### PR DESCRIPTION
The mvn installs are too verbose and users don't know what to enter for `groupId` when prompted.
This change sets default values that can be changed later.
