### PR TITLE
Fixed templated for js_puppeteer

### DIFF
--- a/templates/js_puppeteer/specs/example.spec
+++ b/templates/js_puppeteer/specs/example.spec
@@ -8,4 +8,4 @@ To execute this specification, use
 
 ## Get Started
 * Go to Get Started page
-* Show subtitle "Choose your OS & download" 
+* Show subtitle "Get Started With Gauge"

--- a/templates/js_puppeteer/tests/step_implementation.js
+++ b/templates/js_puppeteer/tests/step_implementation.js
@@ -20,11 +20,11 @@ step("Go to Gauge homepage at <query>", async function (query) {
 });
 
 step("Go to Get Started page", async function () {
-  await page.click(".link-get-started");
+  await page.click(".cta-primary");
 });
 
 step("Show subtitle <title>", async function(title){
-  await page.waitFor('.sub-title');
-  const message = await page.$eval('.sub-title', e => e.innerText);
-  assert.equal(message, title);
+  await page.waitFor('.page-header h1');
+  const message = await page.$eval('.page-header h1', e => e.innerText);
+  assert.strictEqual(message, title);
 });


### PR DESCRIPTION
template trying to run againts old gauge.io page
changed references to elements
changed usage assert.equal to assert.strictEqual due it's deprecation