### PR TITLE
Adding reportserver plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-Gauge-Repository
-================
+# Gauge-Repository
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 This contains the meta-data of [gauge plugins and language runners](https://gauge.org/plugins/) which is used during installation and upgrades.
 
-### Steps to add new plugin details :
+## Steps to add new plugin details
+
 * Add a file with name {plugin_name}-install.json in the base directory.
 * Following snippet shows the json format for the above file.
-```
+
+```json
 {
     "name": "{plugin_name}",
     "description": "{description}",
@@ -43,4 +44,5 @@ This contains the meta-data of [gauge plugins and language runners](https://gaug
     ]
 }
 ```
+
 * For reference, have a look at our [plugin-install.json](https://github.com/getgauge/gauge-repository/blob/master/java-install.json)

--- a/reportserver-install.json
+++ b/reportserver-install.json
@@ -1,0 +1,54 @@
+{
+    "name": "reportserver",
+    "description": "A report plugin that will send the generated html-report to a HTTP fileserver such as gohttpserver.",
+    "versions": [
+        {
+            "version": "0.1.1",
+            "gaugeVersionSupport": {
+                "minimum": "1.0.0",
+                "maximum": ""
+            },
+            "install": {
+                "windows": [],
+                "linux": [],
+                "darwin": []
+            },
+            "DownloadUrls": {
+                "x86": {
+                    "windows": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.1/reportserver-0.1.1-windows.x86.zip",
+                    "linux": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.1/reportserver-0.1.1-linux.x86.zip",
+                    "darwin": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.1/reportserver-0.1.1-darwin.x86.zip"
+                },
+                "x64": {
+                    "windows": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.1/reportserver-0.1.1-windows.x86_64.zip",
+                    "linux": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.1/reportserver-0.1.1-linux.x86_64.zip",
+                    "darwin": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.1/reportserver-0.1.1-darwin.x86_64.zip"
+                }
+            }
+        },
+        {
+            "version": "0.1.0",
+            "gaugeVersionSupport": {
+                "minimum": "1.0.0",
+                "maximum": ""
+            },
+            "install": {
+                "windows": [],
+                "linux": [],
+                "darwin": []
+            },
+            "DownloadUrls": {
+                "x86": {
+                    "windows": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.0/reportserver-0.1.0-windows.x86.zip",
+                    "linux": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.0/reportserver-0.1.0-linux.x86.zip",
+                    "darwin": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.0/reportserver-0.1.0-darwin.x86.zip"
+                },
+                "x64": {
+                    "windows": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.0/reportserver-0.1.0-windows.x86_64.zip",
+                    "linux": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.0/reportserver-0.1.0-linux.x86_64.zip",
+                    "darwin": "https://github.com/sitture/gauge-reportserver/releases/download/v0.1.0/reportserver-0.1.0-darwin.x86_64.zip"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds reportserver plugin to the repository.

Fixes https://github.com/sitture/gauge-reportserver/issues/6