### PR TITLE
Manually update gauge js version

### DIFF
--- a/js-install.json
+++ b/js-install.json
@@ -1,9 +1,7 @@
 {
-    "description": "JavaScript language runner for Gauge", 
-    "name": "js", 
     "versions": [
         {
-            "version": "2.3.14", 
+            "version": "2.3.15", 
             "gaugeVersionSupport": {
                 "minimum": "1.0.0", 
                 "maximum": ""
@@ -12,6 +10,25 @@
                 "windows": [], 
                 "darwin": [], 
                 "linux": []
+            }, 
+            "DownloadUrls": {
+                "x86": {
+                    "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.15/gauge-js-2.3.15.zip", 
+                    "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.15/gauge-js-2.3.15.zip", 
+                    "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.15/gauge-js-2.3.15.zip"
+                }, 
+                "x64": {
+                    "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.15/gauge-js-2.3.15.zip", 
+                    "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.15/gauge-js-2.3.15.zip", 
+                    "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.15/gauge-js-2.3.15.zip"
+                }
+            }
+        }, 
+        {
+            "version": "2.3.14", 
+            "gaugeVersionSupport": {
+                "minimum": "1.0.0", 
+                "maximum": ""
             }, 
             "DownloadUrls": {
                 "x86": {
@@ -24,6 +41,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.14/gauge-js-2.3.14.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.14/gauge-js-2.3.14.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -32,6 +54,11 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
+            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.13/gauge-js-2.3.13.zip", 
@@ -43,11 +70,6 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.13/gauge-js-2.3.13.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.13/gauge-js-2.3.13.zip"
                 }
-            }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
             }
         }, 
         {
@@ -56,11 +78,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.12/gauge-js-2.3.12.zip", 
@@ -72,6 +89,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.12/gauge-js-2.3.12.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.12/gauge-js-2.3.12.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -80,6 +102,11 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
+            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.11/gauge-js-2.3.11.zip", 
@@ -91,11 +118,6 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.11/gauge-js-2.3.11.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.11/gauge-js-2.3.11.zip"
                 }
-            }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
             }
         }, 
         {
@@ -104,11 +126,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.10/gauge-js-2.3.10.zip", 
@@ -120,6 +137,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.10/gauge-js-2.3.10.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.10/gauge-js-2.3.10.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -128,6 +150,11 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
+            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.8/gauge-js-2.3.8.zip", 
@@ -139,11 +166,6 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.8/gauge-js-2.3.8.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.8/gauge-js-2.3.8.zip"
                 }
-            }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
             }
         }, 
         {
@@ -152,11 +174,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.7/gauge-js-2.3.7.zip", 
@@ -168,6 +185,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.7/gauge-js-2.3.7.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.7/gauge-js-2.3.7.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -176,11 +198,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.6/gauge-js-2.3.6.zip", 
@@ -192,6 +209,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.6/gauge-js-2.3.6.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.6/gauge-js-2.3.6.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -200,11 +222,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.5/gauge-js-2.3.5.zip", 
@@ -216,6 +233,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.5/gauge-js-2.3.5.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.5/gauge-js-2.3.5.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -224,11 +246,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.4/gauge-js-2.3.4.zip", 
@@ -240,6 +257,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.4/gauge-js-2.3.4.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.4/gauge-js-2.3.4.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -248,11 +270,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.2/gauge-js-2.3.2.zip", 
@@ -264,6 +281,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.2/gauge-js-2.3.2.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.2/gauge-js-2.3.2.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -272,11 +294,6 @@
                 "minimum": "1.0.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.1/gauge-js-2.3.1.zip", 
@@ -288,6 +305,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.1/gauge-js-2.3.1.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.1/gauge-js-2.3.1.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -296,11 +318,6 @@
                 "minimum": "0.9.8", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.3.0/gauge-js-2.3.0.zip", 
@@ -312,6 +329,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.3.0/gauge-js-2.3.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.3.0/gauge-js-2.3.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -320,11 +342,6 @@
                 "minimum": "0.9.7", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.2.0/gauge-js-2.2.0.zip", 
@@ -336,6 +353,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.2.0/gauge-js-2.2.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.2.0/gauge-js-2.2.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -344,11 +366,6 @@
                 "minimum": "0.9.7", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.1.0/gauge-js-2.1.0.zip", 
@@ -360,6 +377,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.1.0/gauge-js-2.1.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.1.0/gauge-js-2.1.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -368,11 +390,6 @@
                 "minimum": "0.9.6", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.0.3/gauge-js-2.0.3.zip", 
@@ -384,6 +401,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.0.3/gauge-js-2.0.3.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.0.3/gauge-js-2.0.3.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -392,11 +414,6 @@
                 "minimum": "0.9.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.0.2/gauge-js-2.0.2.zip", 
@@ -408,6 +425,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.0.2/gauge-js-2.0.2.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.0.2/gauge-js-2.0.2.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -416,11 +438,6 @@
                 "minimum": "0.8.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.0.1/gauge-js-2.0.1.zip", 
@@ -432,6 +449,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.0.1/gauge-js-2.0.1.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.0.1/gauge-js-2.0.1.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -440,11 +462,6 @@
                 "minimum": "0.8.0", 
                 "maximum": ""
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v2.0.0/gauge-js-2.0.0.zip", 
@@ -456,6 +473,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v2.0.0/gauge-js-2.0.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v2.0.0/gauge-js-2.0.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -464,11 +486,6 @@
                 "minimum": "0.5.1", 
                 "maximum": "0.7.0"
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v1.3.0/gauge-js-1.3.0.zip", 
@@ -480,6 +497,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v1.3.0/gauge-js-1.3.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v1.3.0/gauge-js-1.3.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -488,11 +510,6 @@
                 "minimum": "0.3.2", 
                 "maximum": "0.5.0"
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v1.2.1/gauge-js-1.2.1.zip", 
@@ -504,6 +521,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v1.2.1/gauge-js-1.2.1.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v1.2.1/gauge-js-1.2.1.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -512,11 +534,6 @@
                 "minimum": "0.3.2", 
                 "maximum": "0.5.0"
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v1.2.0/gauge-js-1.2.0.zip", 
@@ -528,6 +545,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v1.2.0/gauge-js-1.2.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v1.2.0/gauge-js-1.2.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -536,11 +558,6 @@
                 "minimum": "0.3.2", 
                 "maximum": "0.5.0"
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v1.1.0/gauge-js-1.1.0.zip", 
@@ -552,6 +569,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v1.1.0/gauge-js-1.1.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v1.1.0/gauge-js-1.1.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -560,11 +582,6 @@
                 "minimum": "0.3.2", 
                 "maximum": "0.5.0"
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v1.0.0/gauge-js-1.0.0.zip", 
@@ -576,6 +593,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v1.0.0/gauge-js-1.0.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v1.0.0/gauge-js-1.0.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -584,11 +606,6 @@
                 "minimum": "0.3.0", 
                 "maximum": "0.5.0"
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v0.2.0/gauge-js-0.2.0.zip", 
@@ -600,6 +617,11 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v0.2.0/gauge-js-0.2.0.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v0.2.0/gauge-js-0.2.0.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }, 
         {
@@ -608,11 +630,6 @@
                 "minimum": "0.3.0", 
                 "maximum": "0.5.0"
             }, 
-            "install": {
-                "windows": [], 
-                "darwin": [], 
-                "linux": []
-            }, 
             "DownloadUrls": {
                 "x86": {
                     "windows": "https://github.com/getgauge/gauge-js/releases/download/v0.1.1/gauge-js-0.1.1.zip", 
@@ -624,7 +641,14 @@
                     "darwin": "https://github.com/getgauge/gauge-js/releases/download/v0.1.1/gauge-js-0.1.1.zip", 
                     "linux": "https://github.com/getgauge/gauge-js/releases/download/v0.1.1/gauge-js-0.1.1.zip"
                 }
+            }, 
+            "install": {
+                "windows": [], 
+                "darwin": [], 
+                "linux": []
             }
         }
-    ]
+    ], 
+    "description": "JavaScript language runner for Gauge", 
+    "name": "js"
 }


### PR DESCRIPTION
The gauge js build failed due to a github action
deprecation but the release was made and tagged

https://github.com/getgauge/gauge-js/releases/tag/v2.3.15

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>