### PR TITLE
Add Jira plugin with initial 0.1.0 version

### DIFF
--- a/jira-install.json
+++ b/jira-install.json
@@ -1,0 +1,30 @@
+{
+    "name": "jira",
+    "description": "A documentation plugin that publishes Gauge specifications to Jira.",
+    "versions": [
+        {
+            "version": "0.1.0",
+            "gaugeVersionSupport": {
+                "minimum": "1.0.7",
+                "maximum": ""
+            },
+            "install": {
+                "windows": [],
+                "linux": [],
+                "darwin": []
+            },
+            "DownloadUrls": {
+                "x86": {
+                    "windows": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.0/gauge-jira-0.1.0-windows.x86.zip",
+                    "linux": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.0/gauge-jira-0.1.0-linux.x86.zip",
+                    "darwin": ""
+                },
+                "x64": {
+                    "windows": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.0/gauge-jira-0.1.0-windows.x86_64.zip",
+                    "linux": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.0/gauge-jira-0.1.0-linux.x86_64.zip",
+                    "darwin": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.0/gauge-jira-0.1.0-darwin.x86_64.zip"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The [Jira plugin][1] is a documentation plugin that publishes Gauge
specifications to Jira.

[1]: https://github.com/agilepathway/gauge-jira

Signed-off-by: John Boyes <154404+johnboyes@users.noreply.github.com>