### PR TITLE
Bump Jira plugin to 0.1.6

### DIFF
--- a/jira-install.json
+++ b/jira-install.json
@@ -3,6 +3,30 @@
     "description": "A documentation plugin that publishes Gauge specifications to Jira.",
     "versions": [
         {
+            "version": "0.1.6",
+            "gaugeVersionSupport": {
+                "minimum": "1.0.7",
+                "maximum": ""
+            },
+            "install": {
+                "windows": [],
+                "linux": [],
+                "darwin": []
+            },
+            "DownloadUrls": {
+                "x86": {
+                    "windows": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.6/gauge-jira-0.1.6-windows.x86.zip",
+                    "linux": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.6/gauge-jira-0.1.6-linux.x86.zip",
+                    "darwin": ""
+                },
+                "x64": {
+                    "windows": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.6/gauge-jira-0.1.6-windows.x86_64.zip",
+                    "linux": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.6/gauge-jira-0.1.6-linux.x86_64.zip",
+                    "darwin": "https://github.com/agilepathway/gauge-jira/releases/download/v0.1.6/gauge-jira-0.1.6-darwin.x86_64.zip"
+                }
+            }
+        },
+        {
             "version": "0.1.5",
             "gaugeVersionSupport": {
                 "minimum": "1.0.7",


### PR DESCRIPTION
This [0.1.6 release][1] [prevents publishing to Jira issues that are
in an invalid state][2]

[1]: https://github.com/agilepathway/gauge-jira/releases/tag/v0.1.6
[2]: https://github.com/agilepathway/gauge-jira/pull/19

Signed-off-by: John Boyes <154404+johnboyes@users.noreply.github.com>