### PR TITLE
Add Confluence plugin with latest version 0.16.0

### DIFF
--- a/confluence-install.json
+++ b/confluence-install.json
@@ -1,0 +1,30 @@
+{
+    "name": "confluence",
+    "description": "A documentation plugin that publishes Gauge specifications to Confluence.",
+    "versions": [
+        {
+            "version": "0.16.0",
+            "gaugeVersionSupport": {
+                "minimum": "1.0.7",
+                "maximum": ""
+            },
+            "install": {
+                "windows": [],
+                "linux": [],
+                "darwin": []
+            },
+            "DownloadUrls": {
+                "x86": {
+                    "windows": "https://github.com/agilepathway/gauge-confluence/releases/download/v0.16.0/gauge-confluence-0.16.0-windows.x86.zip",
+                    "linux": "https://github.com/agilepathway/gauge-confluence/releases/download/v0.16.0/gauge-confluence-0.16.0-linux.x86.zip",
+                    "darwin": ""
+                },
+                "x64": {
+                    "windows": "https://github.com/agilepathway/gauge-confluence/releases/download/v0.16.0/gauge-confluence-0.16.0-windows.x86_64.zip",
+                    "linux": "https://github.com/agilepathway/gauge-confluence/releases/download/v0.16.0/gauge-confluence-0.16.0-linux.x86_64.zip",
+                    "darwin": "https://github.com/agilepathway/gauge-confluence/releases/download/v0.16.0/gauge-confluence-0.16.0-darwin.x86_64.zip"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The [Confluence plugin][1] is a documentation plugin that publishes Gauge
specifications to [Confluence][2] to form living documentation.

[1]: https://github.com/agilepathway/gauge-confluence
[2]: https://www.atlassian.com/software/confluence

Signed-off-by: John Boyes <154404+johnboyes@users.noreply.github.com>